### PR TITLE
Implement the `report` command

### DIFF
--- a/lib/toy_robot/robot.rb
+++ b/lib/toy_robot/robot.rb
@@ -38,6 +38,14 @@ module ToyRobot
       turn(:right)
     end
 
+    def report
+      {
+        north: north,
+        east: east,
+        direction: direction
+      }
+    end
+
     private
 
     def turn(turn_direction)

--- a/spec/toy_robot/robot_spec.rb
+++ b/spec/toy_robot/robot_spec.rb
@@ -118,4 +118,16 @@ RSpec.describe ToyRobot::Robot do
       expect(subject.direction).to eq("NORTH")
     end
   end
+
+  context "#report" do
+    subject { ToyRobot::Robot.new(5, 4, "EAST") }
+
+    it "provides the current location and direction of the robot" do
+      expect(subject.report).to eq({
+                                     east: 5,
+                                     north: 4,
+                                     direction: "EAST"
+                                   })
+    end
+  end
 end


### PR DESCRIPTION
This PR implements a method that reports the position (using 'north' and 'east' as metrics), and the direction the robot is facing.